### PR TITLE
Support LTS 21.1

### DIFF
--- a/hailgun.cabal
+++ b/hailgun.cabal
@@ -82,7 +82,7 @@ library
                         , http-client-tls    >= 0.2 && < 0.4
                         , http-types         >= 0.8
                         , tagsoup            >= 0.13 && < 0.15
-                        , text               == 1.2.*
+                        , text               >= 1.2 && < 2.1
                         , transformers       >= 0.3 && < 0.6
                         , unordered-containers == 0.2.*
                         , filepath           >= 1 && < 2

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,3 @@
-resolver: lts-20.18
+resolver: lts-21.1
 packages:
 - '.'

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    sha256: 9fa4bece7acfac1fc7930c5d6e24606004b09e80aa0e52e9f68b148201008db9
-    size: 649606
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/18.yaml
-  original: lts-20.18
+    sha256: c4381351ba5837a6356fcc0ebeb7a61fdcaf3a085c903a6f730f56b131d5cb58
+    size: 639143
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/21/1.yaml
+  original: lts-21.1


### PR DESCRIPTION
Only needed to relax `text` upper bound.